### PR TITLE
weston: compile fix for 13.0.1

### DIFF
--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -4,6 +4,6 @@
 DEPENDS:append = " rockchip-librga"
 
 SRCREV = "${AUTOREV}"
-SRC_URI:append = " git://github.com/JeffyCN/weston;protocol=https;nobranch=1;branch=${PV}_2024_04_03;"
+SRC_URI:append = " git://github.com/JeffyCN/weston;protocol=https;nobranch=1;branch=${PV}_2024_06_19;"
 SRC_URI:remove = "https://gitlab.freedesktop.org/wayland/weston/-/releases/${PV}/downloads/${BPN}-${PV}.tar.xz2"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
git://github.com/JeffyCN contains a snapshot tag for 13.0.1 from 2024_06_19, but not for 2024_04_03