### PR TITLE
fix: hardcoded /lib causes fatal QA issue

### DIFF
--- a/recipes-graphics/rockchip-libmali/rockchip-libmali.bb
+++ b/recipes-graphics/rockchip-libmali/rockchip-libmali.bb
@@ -83,8 +83,8 @@ do_install:append () {
 			${D}${includedir}/EGL/eglplatform.h
 	fi
 
-	install -d ${D}/lib/firmware
-	install -m 0755 ${WORKDIR}/g25p0-00eac0.mali_csffw.bin ${D}/lib/firmware/g25p0-00eac0.mali_csffw.bin
+	install -d ${D}${libdir}/firmware
+	install -m 0755 ${WORKDIR}/g25p0-00eac0.mali_csffw.bin ${D}${libdir}/firmware/g25p0-00eac0.mali_csffw.bin
 }
 
 INSANE_SKIP:${PN} = "already-stripped ldflags dev-so textrel buildpaths"


### PR DESCRIPTION
Do not hardcode `/lib` but use the built-in `${libdir}` variable which expands to `/usr/lib` (or `/usr/lib32` and `/usr/lib64` when using multilib)

If you do not do this you get following fatal QA Issue errors:
```
ERROR: lib32-rockchip-libmali-1.0-r0 do_package_qa: QA Issue: lib32-rockchip-libmali package is not obeying usrmerge distro feature. /lib should be relocated to /usr. [usrmerge]
ERROR: lib32-rockchip-libmali-1.0-r0 do_package_qa: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /media/ssda/dev/yocto/build/tmp/work/rk3588s_tbs-pokymllib32-linux-gnueabi/lib32-rockchip-libmali/1.0/temp/log.do_package_qa.680131
ERROR: Task (virtual:multilib:lib32:/media/ssda/dev/yocto/meta-rockchip/recipes-graphics/rockchip-libmali/rockchip-libmali.bb:do_package_qa) failed with exit code '1'
ERROR: rockchip-libmali-1.0-r0 do_package_qa: QA Issue: rockchip-libmali package is not obeying usrmerge distro feature. /lib should be relocated to /usr. [usrmerge]
ERROR: rockchip-libmali-1.0-r0 do_package_qa: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /media/ssda/dev/yocto/build/tmp/work/rk3588s_tbs-poky-linux/rockchip-libmali/1.0/temp/log.do_package_qa.711979
ERROR: Task (/media/ssda/dev/yocto/meta-rockchip/recipes-graphics/rockchip-libmali/rockchip-libmali.bb:do_package_qa) failed with exit code '1'
```

Fixes c406519a1ee36e30ab1a3e5201ec4590a283daaa

(Accidentally closed #32 by deleting repo)