### PR TITLE
rk3588: add MACHINEOVERRIDES definition

### DIFF
--- a/conf/machine/include/rk3588.inc
+++ b/conf/machine/include/rk3588.inc
@@ -10,6 +10,7 @@ PREFERRED_VERSION_linux-rockchip := "6.1%"
 LINUXLIBCVERSION := "6.1-custom%"
 
 KBUILD_DEFCONFIG := "rk3588_linux_defconfig"
+MACHINEOVERRIDES .= ":rk3588"
 
 MALI_GPU := "valhall-g610"
 MALI_VERSION := "g13p0"


### PR DESCRIPTION
Add `rk3588` to `MACHINEOVERRIDES` in `rk3588.inc`. This enables SoC-level overrides, allowing configuration changes to apply to all RK3588-based machines.